### PR TITLE
Update cheerio to 0.19.0 to stop warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   ],
   "main": "index.js",
   "dependencies": {
-    "cheerio": "~0.18.0",
+    "cheerio": "~0.19.0",
     "request": "^2.46.0"
   }
 }


### PR DESCRIPTION
Removes these warnings when installing node-scrapy
```
npm WARN deprecated CSSselect@0.4.1: the module is now available as 'css-select'
npm WARN deprecated CSSwhat@0.4.7: the module is now available as 'css-what'
```