### PR TITLE
added 'html' as new option for 'get' which returns content including html tags.

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Part of the selected element(s) to retrieve.
 
 `'text'`: the DOM equivalent of [`Node.textContent`](https://developer.mozilla.org/en-US/docs/Web/API/Node.textContent).
 
-`'html'`: gets the content including html tags. The equivalent of Cheerio's [`html`](https://github.com/cheeriojs/cheerio#html-htmlstring-).
+`'html'`: gets the content including html tags. The equivalent of [`Element.innerHTML`](https://developer.mozilla.org/en-US/docs/Web/API/Element/innerHTML).
 
 `'{attribute}'`: gets the value of the given `attribute`. e.g. `'src'`, '`href`', `'disabled'`, etc.
 

--- a/README.md
+++ b/README.md
@@ -163,6 +163,8 @@ Part of the selected element(s) to retrieve.
 
 `'text'`: the DOM equivalent of [`Node.textContent`](https://developer.mozilla.org/en-US/docs/Web/API/Node.textContent).
 
+`'html'`: gets the content including html tags. The equivalent of Cheerio's [`html`](https://github.com/cheeriojs/cheerio#html-htmlstring-).
+
 `'{attribute}'`: gets the value of the given `attribute`. e.g. `'src'`, '`href`', `'disabled'`, etc.
 
 Default: `'text'`

--- a/index.js
+++ b/index.js
@@ -291,9 +291,14 @@ function getItem(dom, item, defaults) {
      * @type {Function}
      */
 
-    get = (item.get === 'text')
-      ? function(node) { return transform.apply(item.prefix + trim.apply(node.text()) + item.suffix); }
-      : function(node) { return transform.apply(item.prefix + trim.apply(node.attr(item.get)) + item.suffix); };
+    get = (function(i){
+      if (i.get === 'text')
+        return function(node) { return transform.apply(item.prefix + trim.apply(node.text()) + item.suffix); };
+      else if (i.get === 'html') 
+        return function(node) { return transform.apply(item.prefix + trim.apply(node.html()) + item.suffix); };
+      else 
+        return function(node) { return transform.apply(item.prefix + trim.apply(node.attr(item.get)) + item.suffix); };
+    })(item);   
 
     /**
      * When `unique` is set to `true`, only the first match will be returned, no


### PR DESCRIPTION
Currently get option only support 'text' and '{attribute}'. 'text' strips out all html and returns plain text. 

What if I want to preserve the html formatting? 

There is no option to get the content as html. I have added new option 'html' which returns content including all html tags.

Please review and merge this PR.